### PR TITLE
Updates PGLowLatencyAudio to Phonegap/Cordova > 2.1.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 .svn
 */.svn/*
+.*


### PR DESCRIPTION
- Replaces deprecated org.apache.cordova.Plugin API with org.apache.cordova.CordovaPlugin
- Adjusts default value for the number of voices to 1 instead of 0
- This also seems to fix problems I had with the plugin where the sounds were mixed up (all sounds where there, but the wrong sounds were played consequently, i.e. sound2 was played although sound1 should be played)
